### PR TITLE
Remove the branch about artifacts

### DIFF
--- a/guides/npc-gift-tastes.md
+++ b/guides/npc-gift-tastes.md
@@ -136,6 +136,8 @@ if TASTE is neutral and not HAS_UNIVERSAL_NEUTRAL_ID:
       taste = hate
    if item has a price < 20g:
       taste = dislike
+      
+   //This branch never gets executed
    if it's an artifact:
       taste = dislike
       if npc is Penny:


### PR DESCRIPTION
All artifacts currently have no category listed in NPCGiftTastes.xnb.  When the empty string is converted to an int, it defaults to zero.  Since zero is listed under Universal Hates, all artifacts are defaulted to "Hate" and never reach the code block:
   if it's an artifact:
      taste = dislike
      if npc is Penny:
         taste = like